### PR TITLE
Added quoted_text and is_quote keys to comment dict

### DIFF
--- a/nairaland/spiders/crawler.py
+++ b/nairaland/spiders/crawler.py
@@ -79,10 +79,18 @@ class CrawlerSpider(scrapy.Spider):
                         if cr:
                             comment['user'] = cr.text
                             comment['timestamp'] = cd.text
-                            comment['text'] = text.text
                             comment['attachments'] = [i['src'] for i in attachments if i]
                             comment['sex'] = sex.text if sex else "f"
                             comment['pageId'] = idx
+                            if text.find('blockquote'):
+                                quoted_text = text.find('blockquote').text
+                                comment['is_quote'] = True
+                                comment['text'] = text.text.replace(quoted_text, '')
+                                comment['quoted_text'] = quoted_text.split(':')[-1]
+                            else:
+                                comment['is_quote'] = False
+                                comment['text'] = text.text
+                                comment['quoted_text'] = ''
                             comments.append(comment)
                 nairalandItem['comments'] = comments
             yield nairalandItem


### PR DESCRIPTION
- So that NaN does not occur when the comments dict is read into a pandas DataFrame, I explicitly set quoted_text to an empty string when there is no quoted text. 

- I debated the redundancy of is_quote.  It would be a simple matter to check whether or not a post quotes another one anyway. Left it in because it makes this very convenient. 